### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Bystander
 
  The ultimate development automation tool that does nothing but watch 
 directory trees and boardcasts file changes.
-It, however, lets many handy plagins listen to file state change events 
+It, however, lets many handy plugins listen to file state change events 
 and automates every aspect of a development cycle.
   
 The simplest way to automate your entire project from the command-line is run `bystander` in the project root directory with `.bystander` configuration file.


### PR DESCRIPTION
Correct typo 'plagins' to 'plugins'.

This closes #1.
